### PR TITLE
Making it work on python3.10

### DIFF
--- a/pyraylib/__init__.py
+++ b/pyraylib/__init__.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from enum import IntFlag
 from multipledispatch import dispatch
-from collections import (
+from collections.abc import (
     Iterable
 )
 from typing import (

--- a/pyraylib/__init__.py
+++ b/pyraylib/__init__.py
@@ -5,9 +5,12 @@ import os
 from pathlib import Path
 from enum import IntFlag
 from multipledispatch import dispatch
-from collections.abc import (
-    Iterable
-)
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from typing import (
     Any,
     Iterator,


### PR DESCRIPTION
Changes:
- Iterable is imported from collections.abc instead of plain collections library, on pyraylib/__init__.py

Closes #2 