### PR TITLE
Update link to documentation + add markdown file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Pyraylib Documentation
 
-Documentation is hosted [here](https://samybencherif.github.io/pyraylib-documentation/build/html/index.html).
+Documentation is hosted [here](https://samybencherif.github.io/pyraylib-documentation/build/html).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Pyraylib Documentation
+
+Documentation is hosted [here](https://samybencherif.github.io/pyraylib-documentation/build/html/index.html).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html5>
 <html>
   <head>
-    <meta http-equiv="Refresh" content="0; url='https://bensa.games/pyraylib-documentation/build/html'" />
+    <meta http-equiv="Refresh" content="0; url='https://samybencherif.github.io/pyraylib-documentation/build/html/'" />
   </head>
-  <body>Documentation is hosted at <a href="https://bensa.games/pyraylib-documentation/build/html">https://bensa.games/pyraylib-documentation</a>.</body>
+  <body>Documentation is hosted at <a href="https://samybencherif.github.io/pyraylib-documentation/build/html/">https://samybencherif.github.io/pyraylib-documentation/build/html/</a>.</body>
 </html>


### PR DESCRIPTION
- The url https://bensa.games is now used for my game development company, so I'm hosting the docs at https://samybencherif.github.io now
- I've added a readme file to make the docs easy to navigate to from github's interface.